### PR TITLE
remove ignored part of outer.ok calls to splineDesign

### DIFF
--- a/R/ecap_functions.R
+++ b/R/ecap_functions.R
@@ -34,15 +34,13 @@ myns <- function (x, df = NULL, knots = NULL, intercept = FALSE,
     if (any(ol)) {
       k.pivot <- Boundary.knots[1L]
       xl <- cbind(1, x[ol] - k.pivot)
-      tt <- splines::splineDesign(Aknots, rep(k.pivot, 2L), 4, c(0,
-                                                        1), derivs=deriv)
+      tt <- splines::splineDesign(Aknots, rep(k.pivot, 2L), 4, 0, derivs=deriv)
       basis[ol, ] <- xl %*% tt
     }
     if (any(or)) {
       k.pivot <- Boundary.knots[2L]
       xr <- cbind(1, x[or] - k.pivot)
-      tt <- splineDesign(Aknots, rep(k.pivot, 2L), 4, c(0,
-                                                        1), derivs=deriv)
+      tt <- splineDesign(Aknots, rep(k.pivot, 2L), 4, 0, derivs=deriv)
       basis[or, ] <- xr %*% tt
     }
     if (any(inside <- !outside))


### PR DESCRIPTION
In these calls, since deriv= is supplied explicitly, the 4th argument is used as outer.ok.

outer.ok is supposed to be a logical scalar; supplying a vector generates a warning here:

https://github.com/wch/r-source/blob/91a3452726a2e24c798d47d1c96a3f53d7a6e295/src/library/splines/R/splineClasses.R#L57

That warning turns into an error if `_R_CHECK_LENGTH_1_LOGIC2_` is set.

TBH supplying `c(0, 1)` to a logical argument smells like a bug to me, but I am not at all familiar with the package & have no idea what the code is trying to do 😄 -- I'm filing this patch to raise attention to the issue, while also being back-compatible with what the code is currently doing.